### PR TITLE
Install kernel dependency

### DIFF
--- a/shell/dentos-build.sh
+++ b/shell/dentos-build.sh
@@ -14,6 +14,7 @@ echo "---> dentos-build.sh"
 # be careful and verbose
 set -eux -o pipefail
 
+sudo apt-get install -y binfmt-support
 bash tools/autobuild/build.sh -9 -b $STREAM ${BUILD_ARGS:-}
 
 echo "---> dentos-build.sh ends"


### PR DESCRIPTION
For DentOS builds, pre-fetch binfmt-support

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>