### PR TITLE
Update DentOS jobs

### DIFF
--- a/jjb/dentos/dentos-templates.yaml
+++ b/jjb/dentos/dentos-templates.yaml
@@ -17,6 +17,8 @@
     properties:
       - lf-infra-properties:
           build-days-to-keep: "{build-days-to-keep}"
+      - github:
+          url: "{github-url}/{github-org}/{project}"
 
     parameters:
       - lf-infra-parameters:
@@ -45,12 +47,6 @@
 
     build-args: ''
 
-    properties:
-      - lf-infra-properties:
-          build-days-to-keep: "{build-days-to-keep}"
-      - github:
-          url: "{github-url}/{github-org}/{project}"
-
     scm:
       - lf-infra-github-scm:
           url: "{git-clone-url}{github-org}/{project}"
@@ -67,6 +63,46 @@
           trigger-phrase: "^(reverify|recheck)$"
           only-trigger-phrase: true
           status-context: "DentOS verify"
+          permit-all: true
+          github-hooks: true
+          white-list-target-branches:
+            - "{branch}"
+
+    builders:
+      - shell: !include-raw-escape: ../../shell/dentos-build.sh
+
+- job-template:
+    name: "{project-name}-merge-{stream}"
+    id: github-dentos-merge
+    <<: *lf_dentos_common
+
+    build-args: ''
+
+    scm:
+      - lf-infra-github-scm:
+          url: "{git-clone-url}{github-org}/{project}"
+          refspec: ""
+          branch: "refs/heads/{branch}"
+          submodule-recursive: false
+          submodule-timeout: "{submodule-timeout}"
+          submodule-disable: true
+          choosing-strategy: default
+          jenkins-ssh-credential: "{jenkins-ssh-credential}"
+
+    wrappers:
+      - lf-infra-wrappers:
+          build-timeout: "{build-timeout}"
+          jenkins-ssh-credential: "{jenkins-ssh-credential}"
+      - credentials-binding:
+          - username-password:
+             credential-id: dentos
+             variable: DENTOSUSER
+
+    triggers:
+      - github-pull-request:
+          trigger-phrase: "^(remerge)$"
+          only-trigger-phrase: true
+          status-context: "DentOS merge"
           permit-all: true
           github-hooks: true
           white-list-target-branches:

--- a/jjb/dentos/dentos.yaml
+++ b/jjb/dentos/dentos.yaml
@@ -14,4 +14,7 @@
       - 'master':
           branch: 'master'
     jobs:
-      - github-dentos-verify
+      - github-dentos-verify:
+          build-timeout: 270
+      - github-dentos-merge:
+          build-timeout: 270

--- a/shell/dentos-build.sh
+++ b/shell/dentos-build.sh
@@ -15,6 +15,13 @@ echo "---> dentos-build.sh"
 set -eux -o pipefail
 
 sudo apt-get install -y binfmt-support
-bash tools/autobuild/build.sh -9 -b $STREAM ${BUILD_ARGS:-}
+# Build issue under investigation, commenting for now...
+#bash tools/autobuild/build.sh -9 -b $STREAM ${BUILD_ARGS:-}
+make docker
+
+# Push artifact for the merge job
+if [[ "$JOB_NAME" =~ "merge" ]]; then
+    find ${WORKSPACE}/builds/amd64/installer/installed/builds/stretch/ -name '*' -type f -exec curl -u ${DENTOSUSER} -T {} https://nexus.dent.dev/content/repositories/snapshots/org/dent/dentos/ \;
+fi
 
 echo "---> dentos-build.sh ends"


### PR DESCRIPTION
- Increase timeout in verify job to allow
  the build to complete.
- Add merge job
- Update dentos-build.sh for merge job to post
  artifacts in Nexus.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>