### PR TITLE
Save ARM64 binaries for DentOS

### DIFF
--- a/shell/dentos-build.sh
+++ b/shell/dentos-build.sh
@@ -22,6 +22,7 @@ make docker
 # Push artifact for the merge job
 if [[ "$JOB_NAME" =~ "merge" ]]; then
     find ${WORKSPACE}/builds/amd64/installer/installed/builds/stretch/ -name '*' -type f -exec curl -u ${DENTOSUSER} -T {} https://nexus.dent.dev/content/repositories/snapshots/org/dent/dentos/ \;
+    find ${WORKSPACE}/builds/arm64/installer/installed/builds/stretch/ -name '*' -type f -exec curl -u ${DENTOSUSER} -T {} https://nexus.dent.dev/content/repositories/snapshots/org/dent/dentos/ \;
 fi
 
 echo "---> dentos-build.sh ends"


### PR DESCRIPTION
Save both AMD and ARM artifacts for the
dentos-merge job.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>