### PR TITLE
Add DentOS main branch in Jenkins

### DIFF
--- a/jjb/dentos/dentos.yaml
+++ b/jjb/dentos/dentos.yaml
@@ -13,6 +13,9 @@
     stream:
       - 'master':
           branch: 'master'
+      - 'main':
+          branch: 'main'
+
     jobs:
       - github-dentos-verify:
           build-timeout: 270


### PR DESCRIPTION
Add the main branch for Jenkins verify
and merge jobs.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>