### PR TITLE
Fix dentOS project name

### DIFF
--- a/jjb/dentos/dentos.yaml
+++ b/jjb/dentos/dentos.yaml
@@ -1,15 +1,15 @@
 ---
 - project:
     name: dentos-project-view
-    project-name: dentos
+    project-name: dentOS
     views:
       - project-view
 
 - project:
     name: dentos-verify
     build-node: centos7-docker-aws-1c-2g
-    project-name: dentos
-    project: dentos
+    project-name: dentOS
+    project: dentOS
     stream:
       - 'master':
           branch: 'master'
@@ -24,13 +24,13 @@
 
 - project:
     name: dentos-whitesource
-    project-name: dentos
+    project-name: dentOS
     build-node: centos7-docker-aws-1c-2g
     jobs:
       - github-whitesource-scan
-    wss-product-name: dentos
+    wss-product-name: dentOS
     submodule-disable: true
     mvn-clean-install: false
     mvn-settings: dentos-settings
-    project: dentos
+    project: dentOS
     branch: master


### PR DESCRIPTION
The typo was invalidating the triggers for
Jenkins. Make sure the projec name is called
dentOS to match GitHub.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>