### PR TITLE
Restore project-name dentos

### DIFF
--- a/jjb/dentos/dentos.yaml
+++ b/jjb/dentos/dentos.yaml
@@ -1,14 +1,14 @@
 ---
 - project:
     name: dentos-project-view
-    project-name: dentOS
+    project-name: dentos
     views:
       - project-view
 
 - project:
     name: dentos-verify
     build-node: centos7-docker-aws-1c-2g
-    project-name: dentOS
+    project-name: dentos
     project: dentOS
     stream:
       - 'master':
@@ -24,7 +24,7 @@
 
 - project:
     name: dentos-whitesource
-    project-name: dentOS
+    project-name: dentos
     build-node: centos7-docker-aws-1c-2g
     jobs:
       - github-whitesource-scan


### PR DESCRIPTION
Jenkins expects to find the original
dentos project name in the jobs. As long
as "project" is set to "dentOS" to match
GitHub, we should be able to fix the triggers.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>