### PR TITLE
Add self release jobs

### DIFF
--- a/jjb/dentos/dentos.yaml
+++ b/jjb/dentos/dentos.yaml
@@ -10,6 +10,8 @@
     build-node: centos7-docker-aws-1c-2g
     project-name: dentos
     project: dentOS
+    mvn-settings: dentos-settings
+    jenkins-ssh-release-credential: dent
     stream:
       - 'master':
           branch: 'master'
@@ -21,6 +23,8 @@
           build-timeout: 270
       - github-dentos-merge:
           build-timeout: 270
+      - '{project-name}-github-release-jobs':
+          branch: master
 
 - project:
     name: dentos-whitesource


### PR DESCRIPTION
Add self release jobs for DentOS repo
Update global-jjb to the latest version to fetch latest
GitHub support for self releases.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>