### PR TITLE
Skip DentOS verify for release files

### DIFF
--- a/jjb/dentos/dentos-templates.yaml
+++ b/jjb/dentos/dentos-templates.yaml
@@ -14,6 +14,9 @@
     node: "{build-node}"
     disabled: "{disable-job}"
 
+    github_excluded_regions:
+      - '(releases\/.*\.yaml|\.releases\/.*\.yaml)'
+
     properties:
       - lf-infra-properties:
           build-days-to-keep: "{build-days-to-keep}"
@@ -67,6 +70,7 @@
           github-hooks: true
           white-list-target-branches:
             - "{branch}"
+          excluded-regions: "{obj:github_excluded_regions}"
 
     builders:
       - shell: !include-raw-escape: ../../shell/dentos-build.sh


### PR DESCRIPTION
Do not run DentOS verify job for release files.
These files do not contain any code that can affect
DentOS verify and there is no need to run this job
which is pretty lenghty.

The release verify job will take care of run a verify on
releases files and makes sure release file changes are
isolated from any other code changes.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>