### PR TITLE
Allow concurrent verify jobs

### DIFF
--- a/jjb/dentos/dentos-templates.yaml
+++ b/jjb/dentos/dentos-templates.yaml
@@ -49,6 +49,7 @@
     <<: *lf_dentos_common
 
     build-args: ''
+    concurrent: true
 
     scm:
       - lf-infra-github-scm:


### PR DESCRIPTION
Allow DentOS to run concurrent verify
jobs.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>