### PR TITLE
Fix: Add links to aws templates

### DIFF
--- a/packer/templates/builder-aws.json
+++ b/packer/templates/builder-aws.json
@@ -1,0 +1,1 @@
+../common-packer/templates/builder-aws.json

--- a/packer/templates/docker-aws.json
+++ b/packer/templates/docker-aws.json
@@ -1,0 +1,1 @@
+../common-packer/templates/docker-aws.json


### PR DESCRIPTION
Add missing links to builder and docker aws
templates from common-packer

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>