### PR TITLE
Fix: Use Ubuntu node for dentOS builds

### DIFF
--- a/jjb/dentos/dentos.yaml
+++ b/jjb/dentos/dentos.yaml
@@ -7,7 +7,7 @@
 
 - project:
     name: dentos-verify
-    build-node: centos7-docker-aws-1c-2g
+    build-node: prd-ubuntu-docker-aws-1c-2g
     project-name: dentos
     project: dentOS
     mvn-settings: dentos-settings


### PR DESCRIPTION
Use Ubuntu node for dentOS verify and merge jobs

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>