### PR TITLE
Fix: Update replica templates main branch

### DIFF
--- a/jjb/replica/replica-pipeline-templates.yaml
+++ b/jjb/replica/replica-pipeline-templates.yaml
@@ -10,7 +10,7 @@
     # Default parameters #
     ######################
 
-    branch: master
+    branch: main
 
     #####################
     # Job Configuration #


### PR DESCRIPTION
Update "main" default branch for all replica
templates.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>