### PR TITLE
Fix: Update replica daily templates

### DIFF
--- a/jjb/replica/replica-pipeline-templates.yaml
+++ b/jjb/replica/replica-pipeline-templates.yaml
@@ -53,9 +53,9 @@
 # JOB TEMPLATES #
 #################
 - job-template:
-    name: "{project-name}-verify-{stream}-{target}-{tuple}"
-    id: github-replica-verify
-    description: "Job template for replica verify pipeline jobs"
+    name: "{project-name}-daily-{stream}-{target}-{tuple}"
+    id: github-replica-daily
+    description: "Job template for daily replica pipeline jobs"
     <<: *replica_pipeline_common
 
     build-args: ""
@@ -69,17 +69,6 @@
           display-name: "Replica"
 
     triggers:
-      - github-pull-request:
-          github-hooks: true
-          trigger-phrase: "^(recheck|reverify)$"
-          skip-build-phrase: '.*\[WIP\].*'
-          permit-all: true
-          status-context: "Jenkins Replica Verify"
-          triggered-status: "Build is triggered"
-          started-status: "Build is started"
-          success-status: "Tests successfully passed."
-          error-status: "Pipeline execution failed due to technical issue."
-          failure-status: "Pipeline execution failed due to technical issue."
-          cancel-builds-on-update: true
+      - timed: "H H * * 6"
 
     dsl: !include-raw-escape: ../../groovy/replica-pipeline

--- a/jjb/replica/replica.yaml
+++ b/jjb/replica/replica.yaml
@@ -22,42 +22,42 @@
     target: toolchain
     tuple: armv7a-unknown-linux-gnueabihf
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-toolchain-aarch64-unknown-linux-gnu
     defaults: replica-defaults
     target: toolchain
     tuple: aarch64-unknown-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-toolchain-x86_64-multilib-linux-gnu
     defaults: replica-defaults
     target: toolchain
     tuple: x86_64-multilib-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-toolchain-armv7a-unknown-linux-musleabihf
     defaults: replica-defaults
     target: toolchain
     tuple: armv7a-unknown-linux-musleabihf
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-toolchain-aarch64-unknown-linux-musl
     defaults: replica-defaults
     target: toolchain
     tuple: aarch64-unknown-linux-musl
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-toolchain-x86_64-multilib-linux-musl
     defaults: replica-defaults
     target: toolchain
     tuple: x86_64-multilib-linux-musl
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 
 # Device targets
 - project:
@@ -66,56 +66,56 @@
     target: tn48m
     tuple: aarch64-unknown-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-tn4810m-aarch64-unknown-linux-gnu
     defaults: replica-defaults
     target: tn4810m
     tuple: aarch64-unknown-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-tx4810-aarch64-unknown-linux-gnu
     defaults: replica-defaults
     target: tx4810
     tuple: x86_64-multilib-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-as5114-48x-aarch64-unknown-linux-gnu
     defaults: replica-defaults
     target: as5114-48x
     tuple: aarch64-unknown-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-rpi4-aarch64-unknown-linux-gnu
     defaults: replica-defaults
     target: rpi4
     tuple: aarch64-unknown-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-sn2010-x86_64-multilib-linux-gnu
     defaults: replica-defaults
     target: sn2010
     tuple: x86_64-multilib-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-ecw5211-l-t-armv7a-unknown-linux-gnueabihf
     defaults: replica-defaults
     target: ecw5211-l-t
     tuple: armv7a-unknown-linux-gnueabihf
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-methode-udpu-aarch64-unknown-linux-gnu
     defaults: replica-defaults
     target: methode-udpu
     tuple: aarch64-unknown-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 
 # Generic targets
 - project:
@@ -124,21 +124,21 @@
     target: vmlinux
     tuple: armv7a-unknown-linux-gnueabihf
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-vmlinux-aarch64-unknown-linux-gnu
     defaults: replica-defaults
     target: vmlinux
     tuple: aarch64-unknown-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-vmlinux-x86_64-multilib-linux-gnu
     defaults: replica-defaults
     target: vmlinux
     tuple: x86_64-multilib-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 
 # System targets
 - project:
@@ -147,42 +147,42 @@
     target: system
     tuple: armv7a-unknown-linux-gnueabihf
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-system-aarch64-unknown-linux-gnu
     defaults: replica-defaults
     target: system
     tuple: aarch64-unknown-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-system-x86_64-multilib-linux-gnu
     defaults: replica-defaults
     target: system
     tuple: x86_64-multilib-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-system-armv7a-unknown-linux-musleabihf
     defaults: replica-defaults
     target: system
     tuple: armv7a-unknown-linux-musleabihf
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-system-aarch64-unknown-linux-musl
     defaults: replica-defaults
     target: system
     tuple: aarch64-unknown-linux-musl
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 - project:
     name: replica-system-x86_64-multilib-linux-musl
     defaults: replica-defaults
     target: system
     tuple: x86_64-multilib-linux-musl
     jobs:
-      - github-replica-verify
+      - github-replica-daily
 
 # Package targets
 - project:
@@ -191,4 +191,4 @@
     target: package
     tuple: aarch64-unknown-linux-gnu
     jobs:
-      - github-replica-verify
+      - github-replica-daily


### PR DESCRIPTION
Replica verify templates should be rather a daily job
for now. This job will be triggered on a cron every
Saturday.

Further along, we will bring in an actual verify job that
will be trigger on new PRs.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>